### PR TITLE
Remove initial styling for canvas element (width and height)

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -13,7 +13,7 @@ angular.module('signature').directive('signaturePad', ['$window',
     return {
       restrict: 'EA',
       replace: true,
-      template: '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}"><canvas height="{{ height }}" width="{{ width }}" ng-mouseup="updateModel()"></canvas></div>',
+      template: '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}"><canvas ng-mouseup="updateModel()"></canvas></div>',
       scope: {
         accept: '=',
         clear: '=',
@@ -58,9 +58,6 @@ angular.module('signature').directive('signaturePad', ['$window',
       link: function (scope, element) {
         canvas = element.find('canvas')[0];
         scope.signaturePad = new SignaturePad(canvas);
-
-        if (!scope.height) scope.height = 220;
-        if (!scope.width) scope.width = 568;
 
         if (scope.signature && !scope.signature.$isEmpty && scope.signature.dataUrl) {
           scope.signaturePad.fromDataURL(scope.signature.dataUrl);


### PR DESCRIPTION
What I liked about this angular module is a feature that was described in the following statement:

> this library doesn't apply any styling

However, this statement is not completely correct, in fact this library applies a style to the canvas element at the compilation time of the directive. This style consists of the width and height of the canvas.

In addition, a default values for the width and height are used if no values have been provided (568px for the width and 220px for the height), which forces you to provide values for these properties if the default ones are not suitable for your case.

One of those cases is when you have a responsive design and hence you don't have fixed values for width and height, an example can be found in [this plunker](https://plnkr.co/edit/P8bdR3FbfCEaonPwF9JX?p=preview).
In order to see this example properly, open the embedded view, use the device mode of google chrome dev tools and select **Mobile S** layout (320 \* 809), you'll find the canvas width greater than the one of the viewport.

The solution to this issue is to remove the initial styling of the canvas element. The result of applying this solution can be found [here](https://plnkr.co/edit/aGn22cqrUHYzi5iILEXd?p=preview).
