### PR TITLE
Add support for high DPI and responsive signatures

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "extends": "airbnb-base/legacy",
+  "rules": {
+    "func-names": 0,
+    "no-param-reassign": 0,
+    "vars-on-top": 0
+  },
+  "globals": {
+      "angular": false,
+      "SignaturePad": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "angular": ">=1.3 <2.0",
-    "signature_pad": "~1.3"
+    "signature_pad": "~1.5.3"
   }
 }
-

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html class="no-js" lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title></title>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.5/angular.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/signature_pad/1.5.3/signature_pad.js"></script>
+    <script type="text/javascript" src="src/signature.js"></script>
+    <style>
+      .signature {
+        outline: 2px blue solid;
+      }
+    </style>
+  </head>
+  <body ng-app="" ng-strict-di>
+    <signature-pad accept="accept" clear="clear" height="201" width="401"></signature-pad>
+    <button ng-click="clear()">Clear signature</button>
+    <button ng-click="signature = accept()">Sign</button>
+    <script>
+    angular.module('app', ['signature']).controller('SignModalCtrl', function() {
+    });
+
+    angular.element(document).ready(function() {
+      angular.bootstrap(document, ['app']);
+    });
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -15,5 +15,14 @@
   "dependencies": {
     "angular": ">=1.3 <2.0",
     "signature_pad": "~1.5.3"
+  },
+  "devDependencies": {
+    "eslint": "^2.10.2",
+    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-config-xo-space": "^0.13.0",
+    "eslint-plugin-import": "^1.8.0"
+  },
+  "scripts": {
+    "lint": "./node_modules/eslint/bin/eslint.js ."
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "angular-signature",
+  "version": "1.0.0",
+  "description": "AngularJS directive for the [signature pad](https://github.com/szimek/signature_pad/) JavaScript library by szimek.",
+  "main": "src/signature.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/legalthings/angular-signature.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/legalthings/angular-signature/issues"
+  },
+  "homepage": "https://github.com/legalthings/angular-signature#readme",
+  "dependencies": {
+    "angular": ">=1.3 <2.0",
+    "signature_pad": "~1.5.3"
+  }
+}

--- a/responsive_demo.html
+++ b/responsive_demo.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html class="no-js" lang="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title></title>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.5.5/angular.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/signature_pad/1.5.3/signature_pad.js"></script>
+    <script type="text/javascript" src="src/signature.js"></script>
+    <style>
+      .signature-area {
+        outline: 2px blue solid;
+        background-color: #f9fafb;
+        position: relative;
+        width: 100%;
+      }
+      .signature-area:before {
+        content: "";
+        display: block;
+        padding-top: 33.3%;
+      }
+      .signature {
+        width: 100%!important;
+        height: 100%!important;
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+      }
+    </style>
+  </head>
+  <body ng-app="" ng-strict-di>
+    <div class="signature-area">
+      <signature-pad accept="accept" clear="clear" height="333" width="1000"></signature-pad>
+    </div>
+    <button ng-click="clear()">Clear signature</button>
+    <button ng-click="signature = accept()">Sign</button>
+    <script>
+    angular.module('app', ['signature']).controller('SignModalCtrl', function() {});
+
+    angular.element(document).ready(function() {
+      angular.bootstrap(document, ['app']);
+    });
+    </script>
+  </body>
+</html>

--- a/src/signature.js
+++ b/src/signature.js
@@ -72,13 +72,13 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
           var scaleWidth = canvas.width / parent[0].offsetWidth;
           var scaleHeight = canvas.height / parent[0].offsetHeight;
 
-          ctx.resetTransform();
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
           ctx.scale(scaleWidth, scaleHeight);
         }
 
         scope.clear = function() {
           var ctx = canvas.getContext('2d');
-          ctx.resetTransform();
+          ctx.setTransform(1, 0, 0, 1, 0, 0);
           scope.signaturePad.clear();
           scope.dataurl = undefined;
           updateScale();

--- a/src/signature.js
+++ b/src/signature.js
@@ -53,11 +53,6 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
             $scope.dataurl = result.isEmpty ? undefined : result.dataUrl;
           };
 
-          $scope.clear = function () {
-            $scope.signaturePad.clear();
-            $scope.dataurl = undefined;
-          };
-
           $scope.$watch(['width', 'height'], $scope.onResize);
         }
       ],
@@ -79,6 +74,14 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
 
           ctx.resetTransform();
           ctx.scale(scaleWidth, scaleHeight);
+        }
+
+        scope.clear = function() {
+          var ctx = canvas.getContext('2d');
+          ctx.resetTransform();
+          scope.signaturePad.clear();
+          scope.dataurl = undefined;
+          updateScale();
         }
 
         scope.onResize = function () {

--- a/src/signature.js
+++ b/src/signature.js
@@ -86,13 +86,12 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
 
         scope.onResize = function () {
           var ratio = Math.max($window.devicePixelRatio || 1, 1);
+          var newWidth = Math.round(scope.width * ratio);
+          var newHeight = Math.round(scope.height * ratio);
 
-          if (
-              canvas.width !== scope.width * ratio ||
-              canvas.height !== scope.height * ratio
-          ) {
-            canvas.width = scope.width * ratio;
-            canvas.height = scope.height * ratio;
+          if (canvas.width !== newWidth || canvas.height !== newHeight) {
+            canvas.width = newWidth;
+            canvas.height = newHeight;
             scope.signaturePad.clear();
           }
           updateScale();

--- a/src/signature.js
+++ b/src/signature.js
@@ -5,25 +5,35 @@
 
 angular.module('signature', []);
 
-angular.module('signature').directive('signaturePad', ['$window',
-  function ($window) {
+angular.module('signature').directive('signaturePad', ['$window', '$timeout',
+  function ($window, $timeout) {
     'use strict';
 
-    var signaturePad, canvas, element, EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
+    var EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
+
     return {
       restrict: 'EA',
       replace: true,
-      template: '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}"><canvas ng-mouseup="updateModel()"></canvas></div>',
+      template: (
+        '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}">' +
+        '<canvas ng-mouseup="updateModel()" style="width: 100%; height: 100%;"></canvas>' +
+        '</div>'
+      ),
       scope: {
         accept: '=',
         clear: '=',
-        dataurl: '=',
+        dataurl: '=?',
+        isEmpty: '=?',
         height: '@',
         width: '@'
       },
       controller: [
         '$scope',
         function ($scope) {
+          $scope.isEmpty = function () {
+            return $scope.signaturePad.isEmpty();
+          };
+
           $scope.accept = function () {
             var signature = {};
 
@@ -41,40 +51,60 @@ angular.module('signature').directive('signaturePad', ['$window',
           $scope.updateModel = function () {
             var result = $scope.accept();
             $scope.dataurl = result.isEmpty ? undefined : result.dataUrl;
-          }
+          };
 
           $scope.clear = function () {
             $scope.signaturePad.clear();
             $scope.dataurl = undefined;
           };
 
-          $scope.$watch("dataurl", function (dataUrl) {
-            if (dataUrl) {
-              $scope.signaturePad.fromDataURL(dataUrl);
-            }
-          });
+          $scope.$watch(['width', 'height'], $scope.onResize);
         }
       ],
       link: function (scope, element) {
-        canvas = element.find('canvas')[0];
+        var canvas = element.find('canvas')[0];
+        var parent = element;
+        var onDevicePixelRatioChange = $window.matchMedia('(-webkit-device-pixel-ratio:1)');
+
         scope.signaturePad = new SignaturePad(canvas);
 
         if (scope.signature && !scope.signature.$isEmpty && scope.signature.dataUrl) {
           scope.signaturePad.fromDataURL(scope.signature.dataUrl);
         }
 
-        scope.onResize = function() {
-          var canvas = element.find('canvas')[0];
-          var ratio =  Math.max($window.devicePixelRatio || 1, 1);
-          canvas.width = canvas.offsetWidth * ratio;
-          canvas.height = canvas.offsetHeight * ratio;
-          canvas.getContext("2d").scale(ratio, ratio);
+        function updateScale() {
+          var ctx = canvas.getContext('2d');
+          var scaleWidth = canvas.width / parent[0].offsetWidth;
+          var scaleHeight = canvas.height / parent[0].offsetHeight;
+
+          ctx.resetTransform();
+          ctx.scale(scaleWidth, scaleHeight);
         }
 
-        scope.onResize();
+        scope.onResize = function () {
+          var ratio = Math.max($window.devicePixelRatio || 1, 1);
 
-        angular.element($window).bind('resize', function() {
-            scope.onResize();
+          if (
+              canvas.width !== scope.width * ratio ||
+              canvas.height !== scope.height * ratio
+          ) {
+            canvas.width = scope.width * ratio;
+            canvas.height = scope.height * ratio;
+            scope.signaturePad.clear();
+          }
+          updateScale();
+        };
+
+        $timeout(scope.onResize);
+
+        var resizeCallback = scope.onResize.bind(this);
+
+        angular.element($window).bind('resize', resizeCallback);
+        onDevicePixelRatioChange.addListener(resizeCallback);
+
+        scope.$on('$destroy', function removeListeners() {
+          angular.element($window).unbind('resize', resizeCallback);
+          onDevicePixelRatioChange.removeListener(resizeCallback);
         });
       }
     };


### PR DESCRIPTION
Our goal is to create responsive signature. This turns out to be a bit problematic since the underlying library is very much bitmap based. This approach uses predefined size and allows to resize canvas with CSS.

This also fixes problems with high DPI screens and resizing browser window (such as #16 or #11).

See [our responsive demo](https://rawgit.com/fastmonkeys/angular-signature/fix-high-dpi/responsive_demo.html).
