### PR TITLE
updateModel is not invoked when using touch device (wrong PR)

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -13,13 +13,14 @@ angular.module('signature').directive('signaturePad', ['$window',
     return {
       restrict: 'EA',
       replace: true,
-      template: '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}"><canvas ng-mouseup="updateModel()"></canvas></div>',
+      template: '<div class="signature" ng-style="{height: height + \'px\', width: width + \'px\'}"><canvas ng-mouseup="onMouseup()" ng-mousedown="notifyDrawing({ drawing: true })"></canvas></div>',
       scope: {
         accept: '=',
         clear: '=',
         dataurl: '=',
         height: '@',
-        width: '@'
+        width: '@',
+        notifyDrawing: '&onDrawing',
       },
       controller: [
         '$scope',
@@ -36,6 +37,13 @@ angular.module('signature').directive('signaturePad', ['$window',
             }
 
             return signature;
+          };
+
+          $scope.onMouseup = function () {
+            $scope.updateModel();
+
+            // notify that drawing has ended
+            $scope.notifyDrawing({ drawing: false });
           };
 
           $scope.updateModel = function () {
@@ -76,6 +84,24 @@ angular.module('signature').directive('signaturePad', ['$window',
         angular.element($window).bind('resize', function() {
             scope.onResize();
         });
+
+        element.on('touchstart', onTouchstart);
+
+        element.on('touchend', onTouchend);
+
+        function onTouchstart() {
+          scope.$apply(function () {
+            // notify that drawing has started
+            scope.notifyDrawing({ drawing: true });
+          });
+        }
+
+        function onTouchend() {
+          scope.$apply(function () {
+            // notify that drawing has ended
+            scope.notifyDrawing({ drawing: false });
+          });
+        }
       }
     };
   }

--- a/src/signature.js
+++ b/src/signature.js
@@ -76,6 +76,11 @@ angular.module('signature').directive('signaturePad', ['$window',
         angular.element($window).bind('resize', function() {
             scope.onResize();
         });
+
+        // listen to touchend event and updateModel when event is fired
+        element.on('touchend', function () {
+          scope.$apply(scope.updateModel);
+        });
       }
     };
   }


### PR DESCRIPTION
updateModel function is not invoked when touch device is used, this is because this function is invoked only when `mouseup` event is fired (only ng-mouseup directive is used), the fix was to listen to the `touchend` event and invoke updateModel when the event is fired.
