### PR TITLE
dataurl is not reset after resizing window

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -69,6 +69,9 @@ angular.module('signature').directive('signaturePad', ['$window',
           canvas.width = canvas.offsetWidth * ratio;
           canvas.height = canvas.offsetHeight * ratio;
           canvas.getContext("2d").scale(ratio, ratio);
+
+          // reset dataurl
+          scope.dataurl = null;
         }
 
         scope.onResize();


### PR DESCRIPTION
Because the canvas is scaled after the window have been resized, the content of the signature pad (drawn signature) is cleared. However, `dataurl` have not been reset.
