### PR TITLE
mouseup event is handled in angular-signature before being handled in signature.js

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -5,8 +5,8 @@
 
 angular.module('signature', []);
 
-angular.module('signature').directive('signaturePad', ['$window',
-  function ($window) {
+angular.module('signature').directive('signaturePad', ['$window', '$timeout',
+  function ($window, $timeout) {
     'use strict';
 
     var signaturePad, canvas, element, EMPTY_IMAGE = 'data:image/gif;base64,R0lGODlhAQABAAAAACwAAAAAAQABAAA=';
@@ -39,9 +39,16 @@ angular.module('signature').directive('signaturePad', ['$window',
           };
 
           $scope.updateModel = function () {
-            var result = $scope.accept();
-            $scope.dataurl = result.isEmpty ? undefined : result.dataUrl;
-          }
+            /*
+             defer handling mouseup event until $scope.signaturePad handles
+             first the same event
+             */
+            $timeout()
+              .then(function () {
+                var result = $scope.accept();
+                $scope.dataurl = result.isEmpty ? undefined : result.dataUrl;
+              });
+          };
 
           $scope.clear = function () {
             $scope.signaturePad.clear();


### PR DESCRIPTION
When drawing dots in the signature pad, it will be considered as empty (`signature.isEmpty`) because `mouseup` event was handled in angular-signature before being handled in signature_pad.js (handling the event in signature_pad.js will set `this._isEmpty` to false).
This only happens when drawing dots, when drawing a curve in the signature pad, `this._isEmpty` will be set to false when handling the `mousemove` event which will be fired before the `mouseup` event. So when the latter is fired, `this._isEmpty` was already set to false and the signature pad won't be considered as empty.
The solution is to defer handling `mouseup` event in angular-signature (ensuring that handling the same event in signature_pad.js will be done first).
