### PR TITLE
updateModel is not invoked when using touch device

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -86,6 +86,11 @@ angular.module('signature').directive('signaturePad', ['$window', '$timeout',
         angular.element($window).bind('resize', function() {
             scope.onResize();
         });
+
+        // listen to touchend event and updateModel when event is fired
+        element.on('touchend', function () {
+            scope.$apply(scope.updateModel);
+        });
       }
     };
   }


### PR DESCRIPTION
updateModel function is not invoked when touch device is used, this is because only ng-mouseup directive is used, the fix was to listen to the touchend event and invoke updateModel when the event is fired.
