### PR TITLE
Remove code which clears dataURL

### DIFF
--- a/src/signature.js
+++ b/src/signature.js
@@ -48,7 +48,7 @@ angular.module('signature').directive('signaturePad', ['$interval', '$timeout', 
              first the same event
              */
             $timeout().then(function () {
-              $scope.dataurl = $scope.signaturePad.isEmpty() ? EMPTY_IMAGE : $scope.signaturePad.toDataURL();
+              $scope.dataurl = $scope.signaturePad.toDataURL();
             });
           };
 


### PR DESCRIPTION
In using `angular-signature` we found that clicking on the signature pad repeatedly would cause it to clear out.  I tested the `signature_pad` demo and I couldn't reproduce it, but I could reproduce it reliably in the `angular-signature` demo.  Doing some debugging it seemed to come from the `timeout` in `updateModel`.  When I removed the `isEmpty` check (as in this PR) we found that the problem went away and we didn't see any adverse effects.

So we were wondering: what was that code intended to do, and is it still needed?